### PR TITLE
Use DevelopmentTokenSource instead of deprecated SandboxTokenSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The app is configured to connect to the LiveKit homepage agent by default, which
 
 To switch from the default agent to your own, you first need a LiveKit agent to speak with. For a no-code setup, use the [Agent Builder](https://docs.livekit.io/agents/start/builder/). For more customization, try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
-Second, you need a token server. For development, the easiest option is the [sandbox token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/): enable it from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the `sandboxId`.
+Second, you need a token server. For development, the easiest option is the [development token server](https://docs.livekit.io/frontends/build/authentication/development-token-server/): switch on the **Development token server** toggle on your project's [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the **Token server ID** below it.
 
 Then edit `AgentToConnect.current` in `VoiceAgent/VoiceAgentApp.swift`:
 
 ```swift
-static let current: Self = .sandbox(id: "your-sandbox-id")
+static let current: Self = .development(id: "your-token-server-id")
 ```
 
 That single value picks the token source and determines whether video and screen share input are enabled. For any other setup, add a case with your own [token source](#token-generation-in-production).
@@ -76,7 +76,7 @@ If your agent publishes a [virtual avatar](https://docs.livekit.io/agents/integr
 
 ## Token generation in production
 
-In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. Replace the `SandboxTokenSource` in `AgentToConnect.tokenSource` with an `EndpointTokenSource` (as the homepage agent case does) or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation.
+In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. Replace the `DevelopmentTokenSource` in `AgentToConnect.tokenSource` with an `EndpointTokenSource` (as the homepage agent case does) or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation.
 
 ## Running on Simulator
 

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -11,22 +11,23 @@ enum AgentToConnect {
     /// Voice and text only: it does not accept video input.
     case liveKitHomepage
 
-    /// Your own agent, reached through the LiveKit Cloud sandbox token server
+    /// Your own agent, reached through the LiveKit Cloud
+    /// [development token server](https://docs.livekit.io/frontends/build/authentication/development-token-server/)
     /// (development only):
-    /// - Enable the token server from your project's Options on the
+    /// - Switch on the Development token server toggle on your project's
     ///   Settings page: https://cloud.livekit.io/projects/p_/settings/project
-    /// - Pass the sandbox ID from that page here.
-    case sandbox(id: String)
+    /// - Pass the Token server ID shown below the toggle here.
+    case development(id: String)
 
-    /// Change this to `.sandbox(id: "your-sandbox-id")` to talk to your own agent.
+    /// Change this to `.development(id: "your-token-server-id")` to talk to your own agent.
     static let current: Self = .liveKitHomepage
 
     var tokenSource: any TokenSourceConfigurable {
         switch self {
         case .liveKitHomepage:
             HomepageTokenSource()
-        case let .sandbox(id):
-            SandboxTokenSource(id: id)
+        case let .development(id):
+            DevelopmentTokenSource(id: id)
         }
     }
 
@@ -34,7 +35,7 @@ enum AgentToConnect {
     var videoEnabled: Bool {
         switch self {
         case .liveKitHomepage: false
-        case .sandbox: true
+        case .development: true
         }
     }
 }


### PR DESCRIPTION
SDK 2.16.0 deprecated `SandboxTokenSource` (it is now a `@available(*, deprecated, renamed:)` typealias) and renamed it to `DevelopmentTokenSource`. This switches the sample over.

### Changes

- `VoiceAgentApp.swift`: `SandboxTokenSource(id:)` → `DevelopmentTokenSource(id:)`. Same initializer, so this is a straight swap.
- Renamed the `AgentToConnect.sandbox(id:)` case to `.development(id:)` so the sample's own naming tracks the SDK. Anyone who forked this and wrote `.sandbox(id:)` will need to update one line.
- Aligned the terminology with the LiveKit Cloud console, which labels the feature **Development token server** and the value **Token server ID** (it is no longer under project **Options**, and it is no longer called `sandboxId`).
- Linked the current docs page — https://docs.livekit.io/frontends/build/authentication/development-token-server/ — from both the README and the `AgentToConnect.development` doc comment, replacing the stale `/frontends/authentication/tokens/sandbox-token-server/` link.
- Renamed the placeholder to `"your-token-server-id"` to match what you actually copy out of the console.

No "sandbox" references remain in the sample.

### Testing

Tested locally.